### PR TITLE
Woo all products updated successfully banner

### DIFF
--- a/assets/js/admin/plugin-rendering.js
+++ b/assets/js/admin/plugin-rendering.js
@@ -51,6 +51,47 @@ jQuery( document ).ready( function( $ ) {
         });
     });
 
+    /**
+     * Banner dismissed callback
+     */
+       $(document).on('click','.plugin_updated_successfully .notice-dismiss', function (e) {
+        e.preventDefault();
+        $.post( facebook_for_woocommerce_plugin_update.ajax_url, {
+            action: 'wc_banner_post_update_close_action',
+            nonce:  facebook_for_woocommerce_plugin_update.banner_close,
+        }, function (response){
+            data = typeof response === "string" ? JSON.parse(response) : response;
+            if(data.success){
+                // No success condition
+            }   
+        }).fail(function(xhr) {
+            console.error("Error Code:", xhr.status);
+            console.error("Error Message:", xhr.responseText);
+            modal.remove();
+        });
+    });
+
+    /**
+     * Banner dismissed callback
+     * but when master sync is off
+     */
+    $(document).on('click','#plugin_updated_successfully_but_master_sync_off .notice-dismiss', function (e) {
+        e.preventDefault();
+        $.post( facebook_for_woocommerce_plugin_update.ajax_url, {
+            action: 'wc_banner_post_update__master_sync_off_close_action',
+            nonce:  facebook_for_woocommerce_plugin_update.banner_close,
+        }, function (response){
+            data = typeof response === "string" ? JSON.parse(response) : response;
+            if(data.success){
+                // No success condition
+            }   
+        }).fail(function(xhr) {
+            console.error("Error Code:", xhr.status);
+            console.error("Error Message:", xhr.responseText);
+            modal.remove();
+        });
+    });
+
     // Opt out sync controls
      $('.opt_out_of_sync_button').on('click', function(event) {
         event.preventDefault();
@@ -62,5 +103,30 @@ jQuery( document ).ready( function( $ ) {
             }
         });
     })
+
+    // Sync all products 
+    $('#sync_all_products').on('click',function(event) {
+        event.preventDefault();
+        let context = $(this);
+        $.post( facebook_for_woocommerce_plugin_update.ajax_url, {
+            action: 'wc_facebook_sync_all_products',   
+            nonce:  facebook_for_woocommerce_plugin_update.sync_back_in,
+        } ,function (response){
+            data = typeof response === "string" ? JSON.parse(response) : response;
+            if( data.success ) {
+                $('#plugin_updated_successfully_but_master_sync_off').hide();
+                $('#plugin_updated_successfully_after_user_opts_in').show();
+            }
+            else{
+                context.text('Failed to enable sync !')
+                context.css("color", "red");
+                context.css('border', '2px solid red');
+                context.prop('disabled', true);
+            }
+        }).fail(function(xhr) {
+            console.error("Error Code:", xhr.status);
+            console.error("Error Message:", xhr.responseText);
+        });
+    });
 });
 

--- a/includes/Handlers/PluginRender.php
+++ b/includes/Handlers/PluginRender.php
@@ -39,7 +39,7 @@ class PluginRender {
 
 	/** @var string  action */
 	const ACTION_CLOSE_BANNER = 'wc_banner_close_action';
-	
+
 
 	public function __construct( \WC_Facebookcommerce $plugin ) {
 		$this->plugin = $plugin;
@@ -85,10 +85,14 @@ class PluginRender {
 		add_action( 'wp_ajax_nopriv_wc_banner_close_action', [ __CLASS__,'reset_upcoming_version_banners' ] );
 		add_action( 'wp_ajax_wc_facebook_sync_all_products', [ __CLASS__,  'sync_all_clicked' ] );
 		add_action( 'wp_ajax_nopriv_wc_facebook_sync_all_products', [ __CLASS__,'sync_all_clicked' ] );
+		add_action( 'wp_ajax_wc_banner_post_update_close_action', [ __CLASS__,  'reset_plugin_updated_successfully_banner' ] );
+		add_action( 'wp_ajax_nopriv_wc_banner_post_update_close_action', [ __CLASS__,'reset_plugin_updated_successfully_banner' ] );
+		add_action( 'wp_ajax_wc_banner_post_update__master_sync_off_close_action', [ __CLASS__,  'reset_plugin_updated_successfully_but_master_sync_off_banner' ] );
+		add_action( 'wp_ajax_nopriv_wc_banner_post_update__master_sync_off_close_action', [ __CLASS__,'reset_plugin_updated_successfully_but_master_sync_off_banner' ] );
 	}
 
 	public function should_show_banners() {
-		$current_version =  '3.4.12';//$this->plugin->get_version();
+		$current_version = $this->plugin->get_version();
 		/**
 		 * Case when current version is less or equal to latest
 		 * but latest is below 3.4.12
@@ -99,9 +103,8 @@ class PluginRender {
 				return;
 			}
 			add_action( 'admin_notices', [ __CLASS__, 'upcoming_woo_all_products_banner' ], 0, 1 );
-		}
-		else if ( version_compare($current_version, self::ALL_PRODUCTS_PLUGIN_VERSION, '>=')){
-			add_action( 'admin_notices', [ __CLASS__, 'upcoming_woo_all_products_banner' ], 0, 1 );
+		} elseif ( version_compare( $current_version, self::ALL_PRODUCTS_PLUGIN_VERSION, '>=' ) ) {
+			add_action( 'admin_notices', [ __CLASS__, 'plugin_updated_banner' ], 0, 1 );
 		}
 	}
 
@@ -143,48 +146,61 @@ class PluginRender {
 
 		if ( isset( $screen->id ) && 'marketing_page_wc-facebook' === $screen->id ) {
 
-			if ( self::is_master_sync_on() ) {
-				echo '<div class="notice notice-success is-dismissible" style="padding: 15px">
+			if ( self::is_master_sync_on() && ! get_transient( 'plugin_updated_banner_hide' ) ) {
+				echo '<div class="notice notice-success is-dismissible plugin_updated_successfully" style="padding: 15px">
                 <h2>You’ve updated to the latest plugin version</h2>
                     <p>
                         As part of this update, all your products automatically sync to Meta. It may take some time before all your products are synced. If you change your mind, go to WooCommerce > Products and select which products to un-sync. <a href="https://www.facebook.com/business/help/4049935305295468"> About syncing products to Meta </a>
                     </p>
                 </div>';
 			} else {
-				$hidden                 = self::is_master_sync_on();
-				$opted_out_banner_class = $hidden ? 'hidden' : '';
-				$opted_in_banner_class  = ! $hidden ? 'hidden' : '';
+				$is_master_sync_on                     = self::is_master_sync_on();
+				$plugin_updated_and_master_sync_on     = ! $is_master_sync_on || get_transient( 'plugin_updated_banner_hide' ) ? 'hidden' : '';
+				$plugin_updated_but_not_master_sync_on = $is_master_sync_on || get_transient( 'plugin_updated_with_master_sync_off_banner_hide' ) ? 'hidden' : '';
 
-				echo '<div id="opted_out_banner_updated_plugin" class="notice notice-success is-dismissible ' . esc_html( $opted_out_banner_class ) . '"" style="padding: 15px">
-                    <h2>You’ve updated to the latest plugin version</h2>   
-                        <p>
-                            To see all the changes, view the changelog. Since you’ve opted out of automatically syncing all your products, some of your products are not yet on Meta. We recommend turning on auto syncing to help drive your sales and improve ad performance. About syncing products to Meta
-                        </p>
-                        <p>
-                            <a href="javascript:void(0);" class="button wc-forward" id="sync_all_products">
-                                Sync all products
-                            </a>
-                        </p>
-                    </div>';
+				/**
+				 *Showing updated successfully banner after user has already clicked sync all
+				 * This banner will be shown only once and if user decides to dismiss it
+				 * Won't be shown again
+				 */
 
-				echo '<div id="opted_in_banner_updated_plugin" class="notice notice-success is-dismissible ' . esc_html( $opted_in_banner_class ) . '"" style="padding: 15px">
-                    <h2>Your products will be synced automatically</h2>   
-                        <p>
-                            It may take some time before all your products are synced. If you change your mind, go to WooCommerce > Products and select which products to un-sync.<a href="https://www.facebook.com/business/help/4049935305295468"> About syncing products to Meta</a>
-                        </p>
-                    </div>';
+				echo '<div id="plugin_updated_successfully_after_user_opts_in" class="notice notice-success is-dismissible plugin_updated_successfully ' . esc_html( $plugin_updated_and_master_sync_on ) . '"" style="padding: 15px">
+				 <h2>Your products will be synced automatically</h2>   
+					 <p>
+						 It may take some time before all your products are synced. If you change your mind, go to WooCommerce > Products and select which products to un-sync.<a href="https://www.facebook.com/business/help/4049935305295468"> About syncing products to Meta</a>
+					 </p>
+				 </div>';
+
+				/**
+				 * Shows up every fortnight after version 3.4.12
+				 * If and only if the user has opted out and also upgraded the plugin to 3.4.12
+				 */
+
+					echo '<div id="plugin_updated_successfully_but_master_sync_off" class="notice notice-success is-dismissible ' . esc_html( $plugin_updated_but_not_master_sync_on ) . '"" style="padding: 15px">
+					<h2>You’ve updated to the latest plugin version</h2>   
+						<p>
+							To see all the changes, view the changelog. Since you’ve opted out of automatically syncing all your products, some of your products are not yet on Meta. We recommend turning on auto syncing to help drive your sales and improve ad performance. About syncing products to Meta
+						</p>
+						<p>
+							<a href="javascript:void(0);" class="button wc-forward" id="sync_all_products">
+								Sync all products
+							</a>
+						</p>
+					</div>';
+
 			}
 		}
 	}
 
 	public function opt_out_of_sync_clicked() {
-			$latest_date = gmdate( 'Y-m-d H:i:s' );
-			update_option( self::MASTER_SYNC_OPT_OUT_TIME, $latest_date );
-			wp_send_json_success( 'Opted out successfully' );
+		$latest_date = gmdate( 'Y-m-d H:i:s' );
+		update_option( self::MASTER_SYNC_OPT_OUT_TIME, $latest_date );
+		wp_send_json_success( 'Opted out successfully' );
 	}
 
 	public function sync_all_clicked() {
-			update_option( self::MASTER_SYNC_OPT_OUT_TIME, '' );
+		update_option( self::MASTER_SYNC_OPT_OUT_TIME, '' );
+		wp_send_json_success( 'Synced all in successfully' );
 	}
 
 	/**
@@ -192,8 +208,26 @@ class PluginRender {
 	 * after a week
 	 */
 	public function reset_upcoming_version_banners() {
-		set_transient( 'upcoming_woo_all_products_banner_hide', true, 10 ); //7 * DAY_IN_SECONDS );
+		set_transient( 'upcoming_woo_all_products_banner_hide', true, 7 * DAY_IN_SECONDS );
 	}
+
+	/**
+	 * Banner for  WooAllProducts version upgrade will show up
+	 * after a year
+	 * NOTE: We are doing this because anyway we will remove this in cleanup post : 3.4.12
+	 */
+	public function reset_plugin_updated_successfully_banner() {
+		set_transient( 'plugin_updated_banner_hide', true, 12 * MONTH_IN_SECONDS );
+	}
+
+	/**
+	 * Banner for WooAllProducts versiong upgrade will show up
+	 * But this will keep showing every week fortnight if user not synced in
+	 */
+	public function reset_plugin_updated_successfully_but_master_sync_off_banner() {
+		set_transient( 'plugin_updated_with_master_sync_off_banner_hide', true, 20 ); // 2 * WEEK_IN_SECONDS );
+	}
+
 
 
 	private function get_opted_out_successfully_banner_class() {


### PR DESCRIPTION
## Description

This banner shows up after user has upgraded the plugin to WooAllProducts version.

### Type of change

New UI banner

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/2cgfduwc)).
- [] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [] I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this [wiki]([url](https://fburl.com/wiki/nhx73tgs)).